### PR TITLE
Restructured project into Page Object Model (POM)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from playwright.sync_api import sync_playwright
+
+@pytest.fixture(scope="package")
+def setup_browser_page():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=False, slow_mo=100)
+        context = browser.new_context()
+        page = context.new_page()
+        yield page
+        page.context.close()

--- a/pages/login_page.py
+++ b/pages/login_page.py
@@ -1,0 +1,33 @@
+class LoginPage:
+
+    def __init__(self, page):
+        self.page = page
+
+    def navigate_to_login(self):
+
+        self.page.goto("https://www.userlike.com/en/")
+        login_button = self.page.locator('[data-test-id="button-to-login"]')
+        login_button.click()
+        login_modal = self.page.locator('text=Login')
+        login_modal.wait_for()
+        assert login_modal.is_visible(), "Login modal is not visible."
+
+    def login(self, email, password):
+        email_field = self.page.locator("#login-username")
+        email_field.clear()
+        email_field.fill(email)
+
+        password_field = self.page.locator("#login-password")
+        password_field.clear()
+        password_field.fill(password)
+
+        login_submit_button = self.page.locator('[data-test-id="button-to-submit-login-form"]')
+        login_submit_button.click()
+
+    def is_dashboard_visible(self):
+        dashboard_navbar = self.page.locator(".navbar.navbar-fixed-top.navbar-inverse")
+        dashboard_navbar.wait_for()
+        return dashboard_navbar.is_visible()
+
+
+

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,51 +1,13 @@
-from playwright.sync_api import sync_playwright
-import time
+from pages.login_page import LoginPage
+import pytest
 
+def test_successful_login(setup_browser_page):
+    page = setup_browser_page
+    login_page = LoginPage(page)
+    login_page.navigate_to_login()
+    login_page.login("romin5954@gmail.com", "RominRomin!234!234")
+    assert login_page.is_dashboard_visible(), "dashboard is not visible after login."
 
-def test_login():
-    with sync_playwright() as p:
-        browser = p.chromium.launch(headless=False, slow_mo=100)
-        context = browser.new_context()
-        page = context.new_page()
-
-        page.goto("https://www.userlike.com/en/")
-
-        login_button = page.locator('[data-test-id="button-to-login"]')
-        login_button.click()
-        login_modal = page.locator('text=Login')
-        login_modal.wait_for()
-
-        assert login_modal.is_visible(), "the element is not visible"
-
-        email_field = page.locator("#login-username")
-        email_field.clear()
-        email_field.fill("romin5954@gmail.com")
-
-        password_field = page.locator("#login-password")
-        password_field.clear()
-        password_field.fill("RominRomin!234!234")
-
-        login_submitt_button = page.locator('[data-test-id="button-to-submit-login-form"]')
-        login_submitt_button.click()
-
-
-        dashboard_navbar = page.locator(".navbar.navbar-fixed-top.navbar-inverse")
-        dashboard_navbar.wait_for()
-        assert dashboard_navbar.is_visible()
-
-
-
-
-
-
-
-
-
-
-
-
-
-        browser.close()
 
 
 


### PR DESCRIPTION
This commit reorganizes the project by implementing a Page Object Model (POM) design pattern. It separates the test logic, page interactions, and test setup/teardown into the contest” 

- Moved test logic to individual test files in the "tests" directory.
- Created a "pages" directory for encapsulating page interaction methods.
- Defined test setup and teardown in "conftest.py" for consistency :) 