### PR TITLE
introduce browser fixture to handle login for tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,32 @@
 import pytest
 from playwright.sync_api import sync_playwright
+from pages.login_page import LoginPage
 
-@pytest.fixture(scope="package")
-def setup_browser_page():
+
+@pytest.fixture(scope="module")
+def browser():
     with sync_playwright() as p:
-        browser = p.chromium.launch(headless=False, slow_mo=100)
+        browser = p.chromium.launch(headless=False, slow_mo=400)
         context = browser.new_context()
         page = context.new_page()
+
+        login_page = LoginPage(page)
+        login_page.navigate_to_login()
+        login_page.login("romin5954@gmail.com", "RominRomin!234!234")
+
+        yield page  # Provide the logged-in page to the tests
+
+        page.context.close()
+
+
+
+@pytest.fixture(scope="module")
+def setup_browser_page():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=False, slow_mo=300)
+        context = browser.new_context()
+        page = context.new_page()
+        page.goto("https://www.userlike.com/en/")
         yield page
         page.context.close()
+

--- a/tests/test_website_widget.py
+++ b/tests/test_website_widget.py
@@ -1,14 +1,9 @@
-from pages.login_page import LoginPage
 from pages.website_widget_page import WebsiteWidgetPage
 import pytest
 
-@pytest.mark.run(order=1)
-def test_add_widget(setup_browser_page):
-    page = setup_browser_page
-    login_page = LoginPage(page)
-    login_page.navigate_to_login()
-    login_page.login("romin5954@gmail.com", "RominRomin!234!234")
-
+@pytest.mark.run(order=3)
+def test_add_widget(browser):
+    page = browser
     website_widget_page = WebsiteWidgetPage(page)
     website_widget_page.open_website_widget_page()
     assert website_widget_page.is_website_widget_page_visible()
@@ -22,9 +17,9 @@ def test_add_widget(setup_browser_page):
     website_widget_page.close_created_widget()
 
 
-@pytest.mark.run(order=2)
-def test_remove_last_added_widget(setup_browser_page):
-    page = setup_browser_page
+@pytest.mark.run(order=4)
+def test_remove_last_added_widget(browser):
+    page = browser
     widget_row = page.locator("tbody")
     widget_row.wait_for()
     widget_row_numbers = widget_row.locator("tr").count()


### PR DESCRIPTION
 now we have two fixture one for the test_login and one another for other tests which needs to be login before starting the test
 
 - setup_browser_page --> setup and teardown for test_login 
 - browser --> setup and teardown for other tests 